### PR TITLE
feat(github_tools): add CreateSubIssue tool for GitHub sub-issue management

### DIFF
--- a/src/tools/code/github_tools.py
+++ b/src/tools/code/github_tools.py
@@ -150,6 +150,18 @@ class GetNotifications(BaseModel):
     per_page: int = Field(default=30, description="Number of notifications to fetch (default: 30)")
 
 
+class CreateSubIssue(BaseModel):
+    """Create a sub-issue relationship between two issues using the GitHub API.
+    This allows you to break down large tasks into smaller manageable pieces.
+    The sub-issue must belong to the same repository owner as the parent issue."""
+
+    token: str = Field(description="GitHub personal access token with repo scope")
+    repo: str = Field(description="Repository in owner/repo format (e.g. acme/my-project)")
+    issue_number: int = Field(description="The parent issue number that will contain the sub-issue")
+    sub_issue_id: int = Field(description="The ID (not number) of the issue to add as a sub-issue. Note: This is the issue ID, not the issue number.")
+    replace_parent: bool = Field(default=False, description="If true, replace the sub-issue's current parent (default: false)")
+
+
 FETCH_FROM_GITHUB   = pydantic_function_tool(FetchFromGithub)
 CREATE_GITHUB_ISSUE = pydantic_function_tool(CreateGithubIssue)
 PR_TO_GITHUB        = pydantic_function_tool(PrToGithub)
@@ -165,6 +177,7 @@ REPLY_TO_PR = pydantic_function_tool(ReplyToPR)
 GET_MY_OPEN_PRS = pydantic_function_tool(GetMyOpenPRs)
 GET_MY_ISSUES = pydantic_function_tool(GetMyIssues)
 GET_NOTIFICATIONS = pydantic_function_tool(GetNotifications)
+CREATE_SUB_ISSUE = pydantic_function_tool(CreateSubIssue)
 
 GITHUB_TOOL_DEFINITIONS: list = [
     FETCH_FROM_GITHUB,
@@ -180,6 +193,7 @@ GITHUB_TOOL_DEFINITIONS: list = [
     GET_MY_OPEN_PRS,
     GET_MY_ISSUES,
     GET_NOTIFICATIONS,
+    CREATE_SUB_ISSUE,
 ]
 
 
@@ -816,6 +830,53 @@ class GithubToolKit:
                 return {
                     "success": False,
                     "notifications": [],
+                    "message": f"GitHub API error {e.response.status_code}: {error_detail}",
+                }
+
+    @track(step_type="tool")
+    async def create_sub_issue(
+        self,
+        token: str,
+        repo: str,
+        issue_number: int,
+        sub_issue_id: int,
+        replace_parent: bool = False,
+    ) -> dict:
+        """Create a sub-issue relationship between two issues.
+        
+        The sub_issue_id is the issue ID (not the issue number).
+        Both issues must belong to the same repository owner.
+        """
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.post(
+                    f"https://api.github.com/repos/{repo}/issues/{issue_number}/sub_issues",
+                    headers={
+                        "Authorization": f"Bearer {token}",
+                        "Accept": "application/vnd.github+json",
+                        "X-GitHub-Api-Version": "2022-11-28",
+                    },
+                    json={
+                        "sub_issue_id": sub_issue_id,
+                        "replace_parent": replace_parent,
+                    },
+                )
+                response.raise_for_status()
+                data = response.json()
+                return {
+                    "success": True,
+                    "sub_issue_number": data["number"],
+                    "sub_issue_url": data["html_url"],
+                    "parent_issue_number": issue_number,
+                    "message": f"Sub-issue #{data['number']} added to issue #{issue_number}: {data['html_url']}",
+                }
+            except httpx.HTTPStatusError as e:
+                error_detail = e.response.json().get("message", e.response.text)
+                return {
+                    "success": False,
+                    "sub_issue_number": None,
+                    "sub_issue_url": "",
+                    "parent_issue_number": issue_number,
                     "message": f"GitHub API error {e.response.status_code}: {error_detail}",
                 }
 

--- a/tests/tools/test_github_tools.py
+++ b/tests/tools/test_github_tools.py
@@ -17,6 +17,7 @@ from src.tools.code.github_tools import (
     GET_MY_OPEN_PRS,
     GET_MY_ISSUES,
     GET_NOTIFICATIONS,
+    CREATE_SUB_ISSUE,
 )
 
 
@@ -399,6 +400,85 @@ class TestGetNotifications:
         assert call_args.kwargs["params"]["participating"] == "true"
 
 
+class TestCreateSubIssue:
+    """Tests for CreateSubIssue tool."""
+
+    async def test_create_sub_issue_success(self, github_kit):
+        """Test successful creation of sub-issue relationship."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "id": 12345,
+            "number": 5,
+            "html_url": "https://github.com/test/repo/issues/5",
+            "title": "Sub-task",
+            "state": "open",
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = mock_response
+            result = await github_kit.create_sub_issue(
+                token="test-token",
+                repo="test/repo",
+                issue_number=1,
+                sub_issue_id=12345,
+            )
+
+        assert result["success"] is True
+        assert result["sub_issue_number"] == 5
+        assert result["parent_issue_number"] == 1
+        assert "Sub-issue #5 added to issue #1" in result["message"]
+
+    async def test_create_sub_issue_with_replace_parent(self, github_kit):
+        """Test creating sub-issue with replace_parent option."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "id": 12345,
+            "number": 5,
+            "html_url": "https://github.com/test/repo/issues/5",
+            "title": "Sub-task",
+            "state": "open",
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = mock_response
+            result = await github_kit.create_sub_issue(
+                token="test-token",
+                repo="test/repo",
+                issue_number=1,
+                sub_issue_id=12345,
+                replace_parent=True,
+            )
+
+        assert result["success"] is True
+        assert result["sub_issue_number"] == 5
+        # Verify the API was called with replace_parent=true
+        call_args = mock_post.call_args
+        assert call_args.kwargs["json"]["replace_parent"] is True
+
+    async def test_create_sub_issue_api_error(self, github_kit):
+        """Test handling of API error when creating sub-issue."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"message": "Sub-issue not found"}
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Not Found", request=MagicMock(), response=mock_response
+        )
+
+        with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = mock_response
+            result = await github_kit.create_sub_issue(
+                token="test-token",
+                repo="test/repo",
+                issue_number=1,
+                sub_issue_id=99999,
+            )
+
+        assert result["success"] is False
+        assert result["sub_issue_number"] is None
+        assert "Sub-issue not found" in result["message"]
+
+
 class TestToolDefinitions:
     """Tests for tool definitions."""
 
@@ -415,6 +495,7 @@ class TestToolDefinitions:
             GET_MY_OPEN_PRS,
             GET_MY_ISSUES,
             GET_NOTIFICATIONS,
+            CREATE_SUB_ISSUE,
         ]
         for tool in expected_tools:
             assert tool in GITHUB_TOOL_DEFINITIONS, f"{tool} not found in GITHUB_TOOL_DEFINITIONS"


### PR DESCRIPTION
## Summary

This PR adds a new GitHub tool `CreateSubIssue` that allows users to create sub-issue relationships between issues using the latest GitHub API (2024).

## Changes

### New Features

- **CreateSubIssue Pydantic model**: Defines parameters for the sub-issue creation tool
  - `token`: GitHub personal access token with repo scope
  - `repo`: Repository in owner/repo format
  - `issue_number`: The parent issue number
  - `sub_issue_id`: The ID of the issue to add as a sub-issue (note: this is the issue ID, not the issue number)
  - `replace_parent`: Optional flag to replace the sub-issue's current parent

- **create_sub_issue() method**: Implements the API call to GitHub's sub-issue endpoint
  - Uses `POST /repos/{owner}/{repo}/issues/{issue_number}/sub_issues`
  - API version: 2022-11-28
  - Returns success status, sub-issue details, and parent issue number

- **Tool integration**: 
  - Added `CREATE_SUB_ISSUE` tool definition
  - Added to `GITHUB_TOOL_DEFINITIONS` list

### Tests

Added comprehensive test coverage in `TestCreateSubIssue` class:
- `test_create_sub_issue_success`: Verifies successful sub-issue creation
- `test_create_sub_issue_with_replace_parent`: Tests the replace_parent option
- `test_create_sub_issue_api_error`: Validates error handling

## API Reference

- [GitHub REST API - Add sub-issue](https://docs.github.com/en/rest/issues/sub-issues#add-sub-issue)

## Usage Example

```python
result = await github_kit.create_sub_issue(
    token="ghp_xxxxx",
    repo="owner/repo",
    issue_number=1,      # Parent issue
    sub_issue_id=12345,  # Sub-issue ID (not number)
    replace_parent=False
)
```

## Checklist

- [x] Pydantic model with proper field descriptions
- [x] Implementation following existing patterns
- [x] Tool definition added to GITHUB_TOOL_DEFINITIONS
- [x] Unit tests with mock responses
- [x] All tests passing
- [x] Uses latest GitHub API version (2022-11-28)

Closes #26

Closes #26