### PR TITLE
Resolve sub-issue by number, validate before linking, and update tests

### DIFF
--- a/src/tools/code/github/client.py
+++ b/src/tools/code/github/client.py
@@ -649,16 +649,44 @@ class GithubTools:
         token: str,
         repo: str,
         issue_number: int,
-        sub_issue_id: int,
+        sub_issue_number: int,
         replace_parent: bool = False,
     ) -> dict:
         """Create a sub-issue relationship between two issues.
-        
-        The sub_issue_id is the issue ID (not the issue number).
-        Both issues must belong to the same repository owner.
+
+        Resolve sub_issue_number to GitHub's internal issue id first, then
+        create the sub-issue relationship.
         """
         async with httpx.AsyncClient() as client:
             try:
+                issue_response = await client.get(
+                    f"https://api.github.com/repos/{repo}/issues/{sub_issue_number}",
+                    headers={
+                        "Authorization": f"Bearer {token}",
+                        "Accept": "application/vnd.github+json",
+                        "X-GitHub-Api-Version": "2022-11-28",
+                    },
+                )
+                issue_response.raise_for_status()
+                issue_data = issue_response.json()
+                sub_issue_id = issue_data.get("id")
+                if sub_issue_id is None:
+                    return {
+                        "success": False,
+                        "sub_issue_number": None,
+                        "sub_issue_url": "",
+                        "parent_issue_number": issue_number,
+                        "message": f"Could not resolve internal issue id for issue #{sub_issue_number}",
+                    }
+                if issue_data.get("pull_request"):
+                    return {
+                        "success": False,
+                        "sub_issue_number": None,
+                        "sub_issue_url": "",
+                        "parent_issue_number": issue_number,
+                        "message": f"Issue #{sub_issue_number} is a pull request, not a real issue.",
+                    }
+
                 response = await client.post(
                     f"https://api.github.com/repos/{repo}/issues/{issue_number}/sub_issues",
                     headers={
@@ -675,13 +703,16 @@ class GithubTools:
                 data = response.json()
                 return {
                     "success": True,
-                    "sub_issue_number": data["number"],
-                    "sub_issue_url": data["html_url"],
+                    "sub_issue_number": data.get("number"),
+                    "sub_issue_url": data.get("html_url", ""),
                     "parent_issue_number": issue_number,
-                    "message": f"Sub-issue #{data['number']} added to issue #{issue_number}: {data['html_url']}",
+                    "message": f"Sub-issue #{data.get('number')} added to issue #{issue_number}: {data.get('html_url', '')}",
                 }
             except httpx.HTTPStatusError as e:
-                error_detail = e.response.json().get("message", e.response.text)
+                try:
+                    error_detail = e.response.json().get("message", e.response.text)
+                except Exception:
+                    error_detail = e.response.text
                 return {
                     "success": False,
                     "sub_issue_number": None,

--- a/src/tools/code/github/issue.py
+++ b/src/tools/code/github/issue.py
@@ -45,7 +45,7 @@ class CreateSubIssue(BaseModel):
     token: str = Field(description="GitHub personal access token with repo scope")
     repo: str = Field(description="Repository in owner/repo format (e.g. acme/my-project)")
     issue_number: int = Field(description="The parent issue number that will contain the sub-issue")
-    sub_issue_id: int = Field(description="The ID (not number) of the issue to add as a sub-issue. Note: This is the issue ID, not the issue number.")
+    sub_issue_number: int = Field(description="The issue number of the issue to add as a sub-issue.")
     replace_parent: bool = Field(default=False, description="If true, replace the sub-issue's current parent (default: false)")
 
 GET_ISSUE_COMMENTS = pydantic_function_tool(GetIssueComments, name="get_issue_comments")

--- a/tests/tools/test_github_tools.py
+++ b/tests/tools/test_github_tools.py
@@ -416,13 +416,18 @@ class TestCreateSubIssue:
         }
         mock_response.raise_for_status = MagicMock()
 
-        with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+        mock_get_response = MagicMock()
+        mock_get_response.json.return_value = {"id": 12345, "number": 5}
+        mock_get_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get, patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+            mock_get.return_value = mock_get_response
             mock_post.return_value = mock_response
             result = await github_kit.create_sub_issue(
                 token="test-token",
                 repo="test/repo",
                 issue_number=1,
-                sub_issue_id=12345,
+                sub_issue_number=5,
             )
 
         assert result["success"] is True
@@ -442,13 +447,18 @@ class TestCreateSubIssue:
         }
         mock_response.raise_for_status = MagicMock()
 
-        with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+        mock_get_response = MagicMock()
+        mock_get_response.json.return_value = {"id": 12345, "number": 5}
+        mock_get_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get, patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+            mock_get.return_value = mock_get_response
             mock_post.return_value = mock_response
             result = await github_kit.create_sub_issue(
                 token="test-token",
                 repo="test/repo",
                 issue_number=1,
-                sub_issue_id=12345,
+                sub_issue_number=5,
                 replace_parent=True,
             )
 
@@ -456,6 +466,7 @@ class TestCreateSubIssue:
         assert result["sub_issue_number"] == 5
         # Verify the API was called with replace_parent=true
         call_args = mock_post.call_args
+        assert call_args.kwargs["json"]["sub_issue_id"] == 12345
         assert call_args.kwargs["json"]["replace_parent"] is True
 
     async def test_create_sub_issue_api_error(self, github_kit):
@@ -466,18 +477,81 @@ class TestCreateSubIssue:
             "Not Found", request=MagicMock(), response=mock_response
         )
 
-        with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+        mock_get_response = MagicMock()
+        mock_get_response.json.return_value = {"id": 99999, "number": 99}
+        mock_get_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get, patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+            mock_get.return_value = mock_get_response
             mock_post.return_value = mock_response
             result = await github_kit.create_sub_issue(
                 token="test-token",
                 repo="test/repo",
                 issue_number=1,
-                sub_issue_id=99999,
+                sub_issue_number=99,
             )
 
         assert result["success"] is False
         assert result["sub_issue_number"] is None
         assert "Sub-issue not found" in result["message"]
+
+    async def test_create_sub_issue_get_fails(self, github_kit):
+        mock_get_response = MagicMock()
+        mock_get_response.json.return_value = {"message": "Not Found"}
+        mock_get_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Not Found", request=MagicMock(), response=mock_get_response
+        )
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_get_response
+            result = await github_kit.create_sub_issue(
+                token="test-token",
+                repo="test/repo",
+                issue_number=1,
+                sub_issue_number=404,
+            )
+
+        assert result["success"] is False
+        assert "Not Found" in result["message"]
+
+    async def test_create_sub_issue_missing_internal_id(self, github_kit):
+        mock_get_response = MagicMock()
+        mock_get_response.json.return_value = {"number": 5}
+        mock_get_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_get_response
+            result = await github_kit.create_sub_issue(
+                token="test-token",
+                repo="test/repo",
+                issue_number=1,
+                sub_issue_number=5,
+            )
+
+        assert result["success"] is False
+        assert "Could not resolve internal issue id" in result["message"]
+
+    async def test_create_sub_issue_rejects_pull_request(self, github_kit):
+        mock_get_response = MagicMock()
+        mock_get_response.json.return_value = {
+            "id": 12345,
+            "number": 5,
+            "pull_request": {"url": "https://api.github.com/repos/test/repo/pulls/5"},
+        }
+        mock_get_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get, patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+            mock_get.return_value = mock_get_response
+            result = await github_kit.create_sub_issue(
+                token="test-token",
+                repo="test/repo",
+                issue_number=1,
+                sub_issue_number=5,
+            )
+
+        assert result["success"] is False
+        assert "not a real issue" in result["message"]
+        mock_post.assert_not_called()
 
 
 class TestToolDefinitions:
@@ -510,4 +584,3 @@ class TestToolDefinitions:
             assert "name" in func
             assert "description" in func
             assert "parameters" in func
-


### PR DESCRIPTION
### Motivation

- Allow callers to pass a human-friendly issue number when creating a sub-issue and ensure the target is a real issue before attempting to link it.

### Description

- Change `create_sub_issue` to accept `sub_issue_number`, perform a GET to `/repos/{repo}/issues/{sub_issue_number}` to resolve the internal `id`, and reject the operation if the internal id cannot be resolved or the target is a pull request.
- Keep the POST to `/repos/{repo}/issues/{issue_number}/sub_issues` but send the resolved `sub_issue_id` and preserve the `replace_parent` behavior, and make response field access resilient using `.get()`.
- Improve error handling when extracting API error details to guard against non-JSON responses.
- Update the Pydantic tool model by renaming `sub_issue_id` to `sub_issue_number` in `CreateSubIssue` and update/extend unit tests to mock the preliminary GET and cover new failure modes.

### Testing

- Ran the updated test file with `pytest tests/tools/test_github_tools.py -q` which executed the `TestCreateSubIssue` cases and they passed.
- New unit tests include success, `replace_parent` behavior, API POST error handling, GET failure handling, missing internal id handling, and rejection of pull requests, all of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f17e31f4d0833085ccfad087e9af3e)