### PR TITLE
feat(docker): add Dockerfiles, entrypoint, nginx config & .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,38 @@
+# Git
+.git/
+.gitignore
+
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+env/
+venv/
+.mypy_cache/
+.pytest_cache/
+.ruff_cache/
+
+# Environment
+.env
+.envrc
+
+# IDE
+.vscode/
+.idea/
+.cursor/
+
+# Node
+web/node_modules/
+
+# Tests
+tests/
+.coverage
+htmlcov/
+
+# Docker
+docker-compose*.yml
+
+# Others
+*.md
+LICENSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# ─── Stage 1: Build ───
+FROM python:3.12-slim AS builder
+
+# Install uv for fast Python package management
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+WORKDIR /app
+
+# Install dependencies in a cached layer
+COPY pyproject.toml uv.lock ./
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --no-install-project
+
+# ─── Stage 2: Runtime ───
+FROM python:3.12-slim AS runtime
+
+# Only runtime system deps: git for code agents, libpq for asyncpg
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git libpq5 && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy virtual environment from builder
+COPY --from=builder /app/.venv /app/.venv
+ENV PATH="/app/.venv/bin:$PATH"
+
+# Copy application source
+COPY src/ /app/src/
+
+# Copy the entrypoint
+COPY docker/docker-entrypoint.sh /app/docker-entrypoint.sh
+RUN chmod +x /app/docker-entrypoint.sh
+
+EXPOSE 8000
+
+ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,0 +1,26 @@
+# ─── Stage 1: Build React app ───
+FROM node:22-slim AS builder
+
+WORKDIR /app
+
+COPY web/package.json web/package-lock.json* ./
+RUN npm ci --legacy-peer-deps
+
+COPY web/ ./
+RUN npm run build
+
+# ─── Stage 2: Serve with Nginx ───
+FROM nginx:1.27-alpine
+
+# Remove default Nginx config
+RUN rm /etc/nginx/conf.d/default.conf
+
+# Copy custom Nginx config that proxies /v1 and /health to the API backend
+COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
+
+# Copy built static files
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -e
+
+# ── Nexus Docker Entrypoint ──
+# Usage:
+#   docker run ... nexus:latest api          → start FastAPI (uvicorn)
+#   docker run ... nexus:latest worker       → start Celery worker
+#
+# Environment variables (see .env.example):
+#   NEXUS_API_KEY, NEXUS_BASE_URL, NEXUS_MODEL, etc.
+
+CMD="${1:-api}"
+
+case "$CMD" in
+    api)
+        echo "Starting Nexus API server..."
+        exec uvicorn src.server.api.main:app --host 0.0.0.0 --port "${NEXUS_API_PORT:-8000}"
+        ;;
+    worker)
+        echo "Starting Nexus Celery worker..."
+        exec celery -A src.server.celery.app worker \
+            --loglevel="${CELERY_LOGLEVEL:-info}" \
+            --concurrency="${CELERY_CONCURRENCY:-4}" \
+            --queues="${NEXUS_CELERY_QUEUE:-nexus_agent_tasks}"
+        ;;
+    *)
+        echo "Unknown command: $CMD"
+        echo "Usage: docker-entrypoint.sh [api|worker]"
+        exit 1
+        ;;
+esac

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,38 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Gzip compression
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+    # Proxy API calls to the backend
+    location /v1/ {
+        proxy_pass http://nexus-api:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /health {
+        proxy_pass http://nexus-api:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    # Serve static files with cache headers
+    location /assets/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # SPA fallback - all other routes serve index.html
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary
Add Docker build infrastructure for Nexus container deployment.

### Changes
- **`Dockerfile`** — Multi-stage Python 3.12 image using `uv` for dependency management. Supports `api` (uvicorn) and `worker` (Celery) entrypoints via `docker-entrypoint.sh`.
- **`Dockerfile.web`** — Multi-stage React frontend build: Node.js 22 builder → Nginx 1.27-alpine server with API proxy.
- **`docker/nginx.conf`** — Nginx config that serves static React files, proxies `/v1/*` and `/health` to the API backend, and handles SPA fallback routing.
- **`docker/docker-entrypoint.sh`** — Unified shell entrypoint dispatching `api` or `worker` based on first argument.
- **`.dockerignore`** — Excludes git, caches, node_modules, tests, and other non-essential files from build context.

### Usage
```bash
# Build
docker build -t nexus:latest .
docker build -f Dockerfile.web -t nexus-web:latest web/

# Run API
docker run -d --env-file .env nexus:latest api

# Run worker (needs Docker socket for sandbox)
docker run -d --env-file .env -v /var/run/docker.sock:/var/run/docker.sock nexus:latest worker
```