### PR TITLE
feat(docker): complete Docker deployment with Dockerfiles, compose, nginx & entrypoint

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,38 @@
+# Git
+.git/
+.gitignore
+
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+env/
+venv/
+.mypy_cache/
+.pytest_cache/
+.ruff_cache/
+
+# Environment
+.env
+.envrc
+
+# IDE
+.vscode/
+.idea/
+.cursor/
+
+# Node
+web/node_modules/
+
+# Tests
+tests/
+.coverage
+htmlcov/
+
+# Docker
+docker-compose*.yml
+
+# Others
+*.md
+LICENSE

--- a/.env.example
+++ b/.env.example
@@ -1,18 +1,41 @@
+# ── LLM / OpenAI-compatible API ────────────────────────────────────────────────
 NEXUS_API_KEY=your_openai_api_key
 NEXUS_BASE_URL=https://api.openai.com/v1
 NEXUS_MODEL=gpt-4o
 NEXUS_MAX_CONTEXT=128000
 NEXUS_MAX_ATTEMPTS=256
 
+# ── GitHub ─────────────────────────────────────────────────────────────────────
 NEXUS_GITHUB_REPO=owner/repo
 NEXUS_GITHUB_TOKEN=your_tela_github_token
 NEXUS_SOPHIE_GITHUB_TOKEN=your_sophie_github_token
 
+# ── Database & Redis ───────────────────────────────────────────────────────────
+#   Local:  postgresql+asyncpg://nexus:nexus@localhost:5432/nexus
+#   Docker: postgresql+asyncpg://nexus:nexus@postgres:5432/nexus  (set by compose)
 NEXUS_DATABASE_URL=postgresql+asyncpg://nexus:nexus@localhost:5432/nexus
+#   Local:  redis://localhost:6379/0
+#   Docker: redis://redis:6379/0  (set by compose)
 NEXUS_REDIS_URL=redis://localhost:6379/0
 NEXUS_REDIS_MESSAGE_TTL_SECONDS=86400
 
+# ── Celery ─────────────────────────────────────────────────────────────────────
+#   Local:  redis://localhost:6379/0
+#   Docker: redis://redis:6379/0  (set by compose)
 NEXUS_CELERY_BROKER_URL=redis://localhost:6379/0
 NEXUS_CELERY_RESULT_BACKEND=redis://localhost:6379/0
 NEXUS_CELERY_QUEUE=nexus_agent_tasks
 NEXUS_CELERY_VISIBILITY_TIMEOUT_SECONDS=86400
+
+# ── Docker deployment ports (optional) ─────────────────────────────────────────
+# NEXUS_API_PORT=8000
+# NEXUS_WEB_PORT=8080
+# NEXUS_POSTGRES_PORT=5432
+# NEXUS_REDIS_PORT=6379
+
+# ── Celery worker tuning (optional) ────────────────────────────────────────────
+# CELERY_LOGLEVEL=info
+# CELERY_CONCURRENCY=4
+
+# ── Task dispatch ──────────────────────────────────────────────────────────────
+# NEXUS_TASK_DISPATCH_LEASE_SECONDS=60

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# ─── Stage 1: Build ───
+FROM python:3.12-slim AS builder
+
+# Install uv for fast Python package management
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+WORKDIR /app
+
+# Install dependencies in a cached layer
+COPY pyproject.toml uv.lock ./
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --no-install-project
+
+# ─── Stage 2: Runtime ───
+FROM python:3.12-slim AS runtime
+
+# Only runtime system deps: git for code agents, libpq for asyncpg
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git libpq5 && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy virtual environment from builder
+COPY --from=builder /app/.venv /app/.venv
+ENV PATH="/app/.venv/bin:$PATH"
+
+# Copy application source
+COPY src/ /app/src/
+
+# Copy the entrypoint
+COPY docker/docker-entrypoint.sh /app/docker-entrypoint.sh
+RUN chmod +x /app/docker-entrypoint.sh
+
+EXPOSE 8000
+
+ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,0 +1,26 @@
+# ─── Stage 1: Build React app ───
+FROM node:22-slim AS builder
+
+WORKDIR /app
+
+COPY web/package.json web/package-lock.json* ./
+RUN npm ci --legacy-peer-deps
+
+COPY web/ ./
+RUN npm run build
+
+# ─── Stage 2: Serve with Nginx ───
+FROM nginx:1.27-alpine
+
+# Remove default Nginx config
+RUN rm /etc/nginx/conf.d/default.conf
+
+# Copy custom Nginx config that proxies /v1 and /health to the API backend
+COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
+
+# Copy built static files
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,94 @@ services:
     networks:
       - nexus-net
 
+  # ── Application ─────────────────────────────────────────────────────────────
+
+  nexus-api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: nexus:latest
+    restart: unless-stopped
+    command: api
+    ports:
+      - "${NEXUS_API_PORT:-8000}:8000"
+    environment:
+      # LLM
+      NEXUS_API_KEY: "${NEXUS_API_KEY}"
+      NEXUS_BASE_URL: "${NEXUS_BASE_URL:-https://api.openai.com/v1}"
+      NEXUS_MODEL: "${NEXUS_MODEL:-gpt-4o}"
+      NEXUS_MAX_CONTEXT: "${NEXUS_MAX_CONTEXT:-128000}"
+      NEXUS_MAX_ATTEMPTS: "${NEXUS_MAX_ATTEMPTS:-256}"
+      # GitHub
+      NEXUS_GITHUB_REPO: "${NEXUS_GITHUB_REPO:-}"
+      NEXUS_GITHUB_TOKEN: "${NEXUS_GITHUB_TOKEN}"
+      NEXUS_SOPHIE_GITHUB_TOKEN: "${NEXUS_SOPHIE_GITHUB_TOKEN}"
+      # Database
+      NEXUS_DATABASE_URL: "postgresql+asyncpg://nexus:nexus@postgres:5432/nexus"
+      # Redis / Celery
+      NEXUS_REDIS_URL: "redis://redis:6379/0"
+      NEXUS_REDIS_MESSAGE_TTL_SECONDS: "${NEXUS_REDIS_MESSAGE_TTL_SECONDS:-86400}"
+      NEXUS_CELERY_BROKER_URL: "redis://redis:6379/0"
+      NEXUS_CELERY_RESULT_BACKEND: "redis://redis:6379/0"
+      NEXUS_CELERY_QUEUE: "${NEXUS_CELERY_QUEUE:-nexus_agent_tasks}"
+      NEXUS_CELERY_VISIBILITY_TIMEOUT_SECONDS: "${NEXUS_CELERY_VISIBILITY_TIMEOUT_SECONDS:-86400}"
+      # Runner
+      NEXUS_TASK_DISPATCH_LEASE_SECONDS: "${NEXUS_TASK_DISPATCH_LEASE_SECONDS:-60}"
+      # API port
+      NEXUS_API_PORT: "8000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - nexus-net
+
+  nexus-worker:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: nexus:latest
+    restart: unless-stopped
+    command: worker
+    environment:
+      # LLM (same as API)
+      NEXUS_API_KEY: "${NEXUS_API_KEY}"
+      NEXUS_BASE_URL: "${NEXUS_BASE_URL:-https://api.openai.com/v1}"
+      NEXUS_MODEL: "${NEXUS_MODEL:-gpt-4o}"
+      NEXUS_MAX_CONTEXT: "${NEXUS_MAX_CONTEXT:-128000}"
+      NEXUS_MAX_ATTEMPTS: "${NEXUS_MAX_ATTEMPTS:-256}"
+      # GitHub
+      NEXUS_GITHUB_REPO: "${NEXUS_GITHUB_REPO:-}"
+      NEXUS_GITHUB_TOKEN: "${NEXUS_GITHUB_TOKEN}"
+      NEXUS_SOPHIE_GITHUB_TOKEN: "${NEXUS_SOPHIE_GITHUB_TOKEN}"
+      # Database
+      NEXUS_DATABASE_URL: "postgresql+asyncpg://nexus:nexus@postgres:5432/nexus"
+      # Redis / Celery
+      NEXUS_REDIS_URL: "redis://redis:6379/0"
+      NEXUS_REDIS_MESSAGE_TTL_SECONDS: "${NEXUS_REDIS_MESSAGE_TTL_SECONDS:-86400}"
+      NEXUS_CELERY_BROKER_URL: "redis://redis:6379/0"
+      NEXUS_CELERY_RESULT_BACKEND: "redis://redis:6379/0"
+      NEXUS_CELERY_QUEUE: "${NEXUS_CELERY_QUEUE:-nexus_agent_tasks}"
+      NEXUS_CELERY_VISIBILITY_TIMEOUT_SECONDS: "${NEXUS_CELERY_VISIBILITY_TIMEOUT_SECONDS:-86400}"
+      # Runner
+      NEXUS_TASK_DISPATCH_LEASE_SECONDS: "${NEXUS_TASK_DISPATCH_LEASE_SECONDS:-60}"
+      # Celery
+      CELERY_LOGLEVEL: "${CELERY_LOGLEVEL:-info}"
+      CELERY_CONCURRENCY: "${CELERY_CONCURRENCY:-4}"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      nexus-api:
+        condition: service_started
+    # Mount Docker socket for sandbox containers (docker-in-docker)
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      - nexus-net
+
 # ── Persistent volumes ────────────────────────────────────────────────────────
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,6 +143,19 @@ services:
     networks:
       - nexus-net
 
+  nexus-web:
+    build:
+      context: .
+      dockerfile: Dockerfile.web
+    image: nexus-web:latest
+    restart: unless-stopped
+    ports:
+      - "${NEXUS_WEB_PORT:-8080}:80"
+    depends_on:
+      - nexus-api
+    networks:
+      - nexus-net
+
 # ── Persistent volumes ────────────────────────────────────────────────────────
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,68 @@
+# ──────────────────────────────────────────────────────────────────────────────
+#  Nexus — Docker Compose deployment
+# ──────────────────────────────────────────────────────────────────────────────
+#
+#  Services:
+#    postgres      PostgreSQL 16 — persistent task / agent state
+#    redis         Redis 7 — Celery broker, result backend & cache
+#    nexus-api     FastAPI server (uvicorn)
+#    nexus-worker  Celery worker (executes agent coding tasks)
+#    nexus-web     React dashboard served via Nginx
+#
+#  Quick start:
+#    1. cp .env.example .env   # then fill in NEXUS_API_KEY, tokens, etc.
+#    2. docker compose up -d
+#    3. Open http://localhost:8080
+# ──────────────────────────────────────────────────────────────────────────────
+
+version: "3.9"
+
+services:
+  # ── Infrastructure ──────────────────────────────────────────────────────────
+
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: nexus
+      POSTGRES_PASSWORD: nexus
+      POSTGRES_DB: nexus
+    ports:
+      - "${NEXUS_POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - nexus-pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U nexus -d nexus"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+    networks:
+      - nexus-net
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    ports:
+      - "${NEXUS_REDIS_PORT:-6379}:6379"
+    volumes:
+      - nexus-redisdata:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    networks:
+      - nexus-net
+
+# ── Persistent volumes ────────────────────────────────────────────────────────
+
+volumes:
+  nexus-pgdata:
+  nexus-redisdata:
+
+# ── Network ───────────────────────────────────────────────────────────────────
+
+networks:
+  nexus-net:
+    driver: bridge

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -e
+
+# ── Nexus Docker Entrypoint ──
+# Usage:
+#   docker run ... nexus:latest api          → start FastAPI (uvicorn)
+#   docker run ... nexus:latest worker       → start Celery worker
+#
+# Environment variables (see .env.example):
+#   NEXUS_API_KEY, NEXUS_BASE_URL, NEXUS_MODEL, etc.
+
+CMD="${1:-api}"
+
+case "$CMD" in
+    api)
+        echo "Starting Nexus API server..."
+        exec uvicorn src.server.api.main:app --host 0.0.0.0 --port "${NEXUS_API_PORT:-8000}"
+        ;;
+    worker)
+        echo "Starting Nexus Celery worker..."
+        exec celery -A src.server.celery.app worker \
+            --loglevel="${CELERY_LOGLEVEL:-info}" \
+            --concurrency="${CELERY_CONCURRENCY:-4}" \
+            --queues="${NEXUS_CELERY_QUEUE:-nexus_agent_tasks}"
+        ;;
+    *)
+        echo "Unknown command: $CMD"
+        echo "Usage: docker-entrypoint.sh [api|worker]"
+        exit 1
+        ;;
+esac

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,38 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Gzip compression
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+    # Proxy API calls to the backend
+    location /v1/ {
+        proxy_pass http://nexus-api:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /health {
+        proxy_pass http://nexus-api:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    # Serve static files with cache headers
+    location /assets/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # SPA fallback - all other routes serve index.html
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary
Complete Docker deployment for Nexus — 7 files, 362 lines. Closes #77.

### Work Item 1 — Dockerfiles & Build Infrastructure
- **`Dockerfile`** — Multi-stage Python 3.12: `uv` builds `.venv` from `pyproject.toml` + `uv.lock`; runtime copies only `.venv` + `src/`, installs `git` + `libpq5`. Entrypoint: `docker-entrypoint.sh`.
- **`Dockerfile.web`** — Multi-stage React: Node 22 builds → Nginx 1.27-alpine serves with `docker/nginx.conf`.
- **`docker/nginx.conf`** — Proxies `/v1/*` and `/health` to `nexus-api:8000`, static asset caching, SPA fallback.
- **`docker/docker-entrypoint.sh`** — Dispatches `api` (uvicorn) or `worker` (Celery) based on CLI argument.
- **`.dockerignore`** — Excludes git, caches, venvs, node_modules, tests, IDE files.

### Work Item 2 — Docker Compose Orchestration
- **`docker-compose.yml`** — 5 services:
  - `postgres` (16-alpine) — persistent data, healthcheck
  - `redis` (7-alpine) — Celery broker + cache, healthcheck
  - `nexus-api` — FastAPI on port 8000, depends on healthy postgres+redis
  - `nexus-worker` — Celery with Docker socket mount for sandbox (docker-in-docker)
  - `nexus-web` — React dashboard on port 8080, Nginx proxy to API
  - Named volumes + bridge network
- **`.env.example`** — Reorganized with Docker vs local deployment comments, added optional port/Celery tuning vars.

### Quick Start
```bash
cp .env.example .env   # fill NEXUS_API_KEY, tokens
docker compose up -d
curl http://localhost:8000/health
open http://localhost:8080
```

Closes #77