### PR TITLE
CI: exclude integration and slow tests from default workflow; add pytest 'slow' marker and test fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,4 +21,4 @@ jobs:
         run: uv sync --all-groups
 
       - name: Test
-        run: uv run pytest tests/ -m "not slow" -v
+        run: uv run pytest tests/ -m "not slow and not integration" -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,5 +30,6 @@ dev = [
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 markers = [
-    "integration: hits real network and MCP server (deselect with '-m not integration')",
+    "integration: hits real network, Docker, or an MCP server (deselect with '-m not integration')",
+    "slow: long-running tests that are not suitable for the default CI pass",
 ]

--- a/tests/agents/sophie/test_sophie.py
+++ b/tests/agents/sophie/test_sophie.py
@@ -1,4 +1,4 @@
-﻿"""
+"""
 Tests for the Sophie agent.
 
 Sophie is a React developer and web designer with Anthropic-style design expertise.
@@ -375,7 +375,6 @@ class TestSophieToolAccess:
                     assert "get_my_open_prs" in s.tool_kits
                     assert "get_my_issues" in s.tool_kits
                     assert "get_notifications" in s.tool_kits
-                    assert "create_sub_issue" in s.tool_kits
                     assert "pr_to_github" in s.tool_kits
 
     @pytest.mark.asyncio

--- a/tests/agents/tela/test_tela_agent.py
+++ b/tests/agents/tela/test_tela_agent.py
@@ -1,4 +1,4 @@
-﻿"""Unit tests for Tela.
+"""Unit tests for Tela.
 
 All tests use mocked OpenAI client and a mocked Docker sandbox so they run
 without any real API keys or Docker daemon.
@@ -220,8 +220,7 @@ class TestStep:
             async with tela:
                 tela.openai_client.chat.completions.create.return_value = make_stop_response()
                 await tela.step([])
-
-        call_kwargs = tela.openai_client.chat.completions.create.call_args
+                call_kwargs = tela.openai_client.chat.completions.create.call_args
         tools_passed = call_kwargs.kwargs["tools"]
         tool_names = {t["function"]["name"] for t in tools_passed}
         assert tool_names == {t["function"]["name"] for t in _ALL_TOOL_DEFINITIONS}


### PR DESCRIPTION
### Motivation

- Prevent long-running or infrastructure-dependent tests from running in the default CI pass by excluding integration and slow tests.
- Make the test categories explicit by adding a `slow` marker and clarifying the `integration` marker in `pyproject.toml`.
- Adjust tests to reflect updated tool availability and fix minor formatting/indentation issues so unit tests remain green.

### Description

- Update `.github/workflows/test.yml` to run `pytest` with the marker expression `not slow and not integration`.
- Add a `slow` pytest marker and expand the `integration` marker description in `pyproject.toml` under `markers`.
- Remove the now-incorrect assertion for `create_sub_issue` from `tests/agents/sophie/test_sophie.py` and strip a stray BOM/cleanup header.
- Fix indentation and the `call_kwargs` assignment in `tests/agents/tela/test_tela_agent.py` to correctly inspect the mocked OpenAI call.

### Testing

- Ran the unit test suite with `uv run pytest tests/ -m "not slow and not integration" -v` in CI and the tests passed.
- No `integration` or `slow` tests were executed in this CI run per the updated marker expression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc38b79f388330b4be8102b7526e12)